### PR TITLE
Add the condition to check null for user

### DIFF
--- a/library/notifications/BaseNotificationService.php
+++ b/library/notifications/BaseNotificationService.php
@@ -135,11 +135,11 @@ class BaseNotificationService extends \yii\base\Behavior
             $name     = ArrayUtil::getValue($settings, 'fromName', null);
         }
         $super  = UserDAO::getById(User::SUPER_USER_ID);
-        if($email == null)
+        if($email == null && $super !== false)
         {
             $email = $super['email'];
         }
-        if($name == null)
+        if($name == null && $super !== false)
         {
             $name = $super['firstname'] . ' ' . $super['lastname'];
         }


### PR DESCRIPTION
If the super is not created during the install and when the class is invoked, it would throw an error.